### PR TITLE
Expand travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,57 @@
-language: rust
+language:
+  - rust
+  - node_js
 cache: cargo
-sudo: false
+sudo: required
+services: docker
+
+node_js:
+  - "node"
+
 rust:
   - stable
   - beta
   - nightly
+
+env:
+  matrix:
+    - TARGET="x86_64-unknown-linux-gnu"
+    - TARGET="mips-unknown-linux-gnu"
+    - TARGET="mipsel-unknown-linux-gnu"
+    - TARGET="mips64-unknown-linux-gnuabi64"
+    - TARGET="mips64el-unknown-linux-gnuabi64"
+    - TARGET="aarch64-unknown-linux-gnu"
+
+addons:
+  apt:
+    packages:
+      - build-essential
+
+before_install:
+  - command -v cross 1>/dev/null || cargo install cross
+  - npm install -g npm@latest
+  - npm install -g ganache-cli@latest truffle@latest
+
 script:
-  - cargo build --verbose --all
-  - cargo test --verbose --all
+  - cross build --target $TARGET --verbose --all
+  - cross test --target $TARGET --verbose --all
+
 matrix:
   allow_failures:
-  - rust: nightly
+    - rust: nightly
   fast_finish: true
   include:
-  - rust: stable
-    script:
-    - rustup component add rustfmt-preview
-    - cargo fmt --all -- --check
+    - rust: stable
+      ? env
+      ? before_install
+      script:
+        - rustup component add rustfmt-preview
+        - cargo fmt --all -- --check
+    - rust: stable
+      ? env
+      ? before_install
+      before_script:
+      - source scripts/chain-prep.sh
+      script:
+      - cargo test --verbose -- --ignored testnet
+

--- a/scripts/chain-prep.sh
+++ b/scripts/chain-prep.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#set -eux
+killall node
+ganache-cli -u 0 -u 1 -u 2 -m 'cook mango twist then skin sort option civil have still rather guilt' &
+git clone https://github.com/althea-mesh/simple-bidirectional-erc20-channel contract
+pushd contract 
+npm install .
+truffle compile
+addresses="$(truffle migrate --verbose)"
+export CHANNEL_ADDRES=`jq -r '.networks| to_entries | sort_by(.key) | last.value.address' build/contracts/ChannelManager.json`
+export CHANNEL_ADDRES=`jq -r '.networks| to_entries | sort_by(.key) | last.value.address' build/contracts/SimpleToken.json`
+popd


### PR DESCRIPTION
This change to travis sets up ganache and deploys the ChannelManager contract. The address of the contract can then be read from the environmental var channel_address. 

I think we should have gauc tests read the env var and then connect to ganache to run against a real testing environment. 