### PR TITLE
Web3 integration

### DIFF
--- a/guac_core/src/crypto.rs
+++ b/guac_core/src/crypto.rs
@@ -54,6 +54,7 @@ pub trait CryptoService {
     // Async stuff
     fn get_network_id(&self) -> Box<Future<Item = u64, Error = Error>>;
     fn get_nonce(&self) -> Box<Future<Item = Uint256, Error = Error>>;
+    fn get_gas_price(&self) -> Box<Future<Item = Uint256, Error = Error>>;
 }
 
 impl Crypto {
@@ -141,6 +142,18 @@ impl CryptoService for Arc<RwLock<Crypto>> {
             self.web3()
                 .eth()
                 .transaction_count(self.own_eth_addr().to_string().parse().unwrap(), None)
+                .into_future()
+                .map_err(GuacError::from)
+                .from_err()
+                // Ugly conversion routine from ethereum-types -> clarity
+                .map(|value| value.to_string().parse().unwrap()),
+        )
+    }
+    fn get_gas_price(&self) -> Box<Future<Item = Uint256, Error = Error>> {
+        Box::new(
+            self.web3()
+                .eth()
+                .gas_price()
                 .into_future()
                 .map_err(GuacError::from)
                 .from_err()

--- a/guac_core/src/crypto.rs
+++ b/guac_core/src/crypto.rs
@@ -18,7 +18,7 @@ use num256::Uint256;
 use std::time;
 use web3::types::{Bytes, FilterBuilder, Log};
 
-/// A global object which stores per node crypto state
+/// A global object which is responsible for managing all crypo related things.
 lazy_static! {
     pub static ref CRYPTO: Arc<RwLock<Crypto>> = Arc::new(RwLock::new(Crypto::new()));
 }
@@ -35,7 +35,7 @@ pub struct Config {
 pub struct Crypto {
     pub secret: PrivateKey,
 
-    /// This is a local balance which is just a hack for testing things
+    /// This is a cached local balance
     pub balance: Uint256,
 
     // Handle to a Web3 instance

--- a/guac_core/src/crypto.rs
+++ b/guac_core/src/crypto.rs
@@ -17,6 +17,8 @@ lazy_static! {
 pub struct Config {
     /// Network address
     pub address: String,
+    /// Address for the contract
+    pub contract: Address,
 }
 
 pub struct Crypto {
@@ -27,6 +29,9 @@ pub struct Crypto {
 
     // Handle to a Web3 instance
     pub web3: Option<Web3Handle>,
+
+    /// Contract address
+    pub contract: Address,
 }
 
 pub trait CryptoService {
@@ -52,6 +57,7 @@ impl Crypto {
             balance: 1_000_000_000_000u64.into(),
             // TODO: Proper connecting
             web3: None,
+            contract: Address::default(),
         }
     }
 }
@@ -60,6 +66,7 @@ impl CryptoService for Arc<RwLock<Crypto>> {
     fn init(&self, config: &Config) -> Result<(), Error> {
         let mut service = self.write().unwrap();
         service.web3 = Some(Web3Handle::new(&config.address)?);
+        service.contract = config.contract.clone();
         Ok(())
     }
     fn own_eth_addr(&self) -> Address {

--- a/guac_core/src/crypto.rs
+++ b/guac_core/src/crypto.rs
@@ -27,6 +27,8 @@ pub struct Config {
     pub address: String,
     /// Address for the contract
     pub contract: Address,
+    /// Private key
+    pub secret: PrivateKey,
 }
 
 pub struct Crypto {
@@ -97,6 +99,7 @@ impl CryptoService for Arc<RwLock<Crypto>> {
         let mut service = self.write().unwrap();
         service.web3 = Some(Web3Handle::new(&config.address)?);
         service.contract = config.contract.clone();
+        service.secret = config.secret.clone();
         Ok(())
     }
     fn own_eth_addr(&self) -> Address {

--- a/guac_core/src/error.rs
+++ b/guac_core/src/error.rs
@@ -2,8 +2,14 @@ use std::sync::Mutex;
 use web3;
 
 #[derive(Debug, Fail)]
-pub enum Error {
+pub enum GuacError {
     // TODO: How to store web3::Error properly instead of string and to avoid weird threading errors?
     #[fail(display = "Web3 error: {}", _0)]
     Web3Error(String),
+}
+
+impl From<web3::Error> for GuacError {
+    fn from(e: web3::Error) -> GuacError {
+        GuacError::Web3Error(format!("{}", e))
+    }
 }

--- a/guac_core/src/error.rs
+++ b/guac_core/src/error.rs
@@ -1,0 +1,9 @@
+use std::sync::Mutex;
+use web3;
+
+#[derive(Debug, Fail)]
+pub enum Error {
+    // TODO: How to store web3::Error properly instead of string and to avoid weird threading errors?
+    #[fail(display = "Web3 error: {}", _0)]
+    Web3Error(String),
+}

--- a/guac_core/src/lib.rs
+++ b/guac_core/src/lib.rs
@@ -22,11 +22,14 @@ extern crate qutex;
 extern crate log;
 extern crate num256;
 extern crate sha3;
+extern crate web3;
 
 pub mod channel_client;
 pub mod counterparty;
 pub mod crypto;
+pub mod error;
 pub mod eth_client;
+pub mod network;
 pub mod storage;
 
 pub use crypto::CRYPTO;

--- a/guac_core/src/network.rs
+++ b/guac_core/src/network.rs
@@ -1,0 +1,26 @@
+use error::Error;
+use std::ops::Deref;
+use web3::transports::{EventLoopHandle, Http};
+use web3::Web3;
+
+/// A handle that contains event loop instance and a web3 instance
+///
+/// EventLoop has to live at least as long as the "Web3" object, or
+/// otherwise calls will fail. We achieve this by implementing a Deref
+/// trait that would return a borrowed Web3 object.
+pub struct Web3Handle(EventLoopHandle, Web3<Http>);
+
+impl Deref for Web3Handle {
+    type Target = Web3<Http>;
+    fn deref(&self) -> &Web3<Http> {
+        &self.1
+    }
+}
+
+impl Web3Handle {
+    pub fn new(address: &str) -> Result<Web3Handle, Error> {
+        let (evloop, transport) =
+            Http::new(&address).map_err(|e| Error::Web3Error(format!("{}", e)))?;
+        Ok(Web3Handle(evloop, Web3::new(transport)))
+    }
+}

--- a/guac_core/src/network.rs
+++ b/guac_core/src/network.rs
@@ -1,8 +1,8 @@
-use error::Error;
+use error::GuacError;
+use failure::Error;
 use std::ops::Deref;
 use web3::transports::{EventLoopHandle, Http};
 use web3::Web3;
-
 /// A handle that contains event loop instance and a web3 instance
 ///
 /// EventLoop has to live at least as long as the "Web3" object, or
@@ -19,8 +19,7 @@ impl Deref for Web3Handle {
 
 impl Web3Handle {
     pub fn new(address: &str) -> Result<Web3Handle, Error> {
-        let (evloop, transport) =
-            Http::new(&address).map_err(|e| Error::Web3Error(format!("{}", e)))?;
+        let (evloop, transport) = Http::new(&address).map_err(GuacError::from)?;
         Ok(Web3Handle(evloop, Web3::new(transport)))
     }
 }

--- a/guac_core/tests/contract_test.rs
+++ b/guac_core/tests/contract_test.rs
@@ -453,4 +453,8 @@ fn init_and_query() {
     assert_eq!(CRYPTO.get_network_id().wait().unwrap(), *NETWORK_ID);
     assert_eq!(CRYPTO.get_nonce().wait().unwrap(), Uint256::from(0u64));
     assert_ne!(CRYPTO.get_gas_price().wait().unwrap(), Uint256::from(0u64));
+    assert_eq!(
+        CRYPTO.get_network_balance().wait().unwrap(),
+        Uint256::from(0u64)
+    );
 }

--- a/guac_core/tests/contract_test.rs
+++ b/guac_core/tests/contract_test.rs
@@ -12,6 +12,7 @@ use clarity::abi::{derive_signature, encode_call, encode_tokens, Token};
 use clarity::{Address, PrivateKey, Transaction};
 use failure::Error;
 use guac_core::channel_client::channel_manager::ChannelManager;
+use guac_core::crypto::Config;
 use guac_core::crypto::CryptoService;
 use guac_core::crypto::CRYPTO;
 use guac_core::eth_client::create_close_channel_payload;
@@ -437,4 +438,14 @@ fn contract() {
 
     assert!(alice_balance < Uint256::from_str("9500000000000000000").unwrap());
     assert!(bob_balance >= Uint256::from_str("10490000000000000000").unwrap());
+}
+
+#[test]
+#[ignore]
+fn init_and_query() {
+    let cfg = Config {
+        address: "http://127.0.0.1:8545".to_string(),
+    };
+    CRYPTO.init(&cfg).unwrap();
+    assert_ne!(CRYPTO.web3().eth().accounts().wait().unwrap().len(), 0);
 }

--- a/guac_core/tests/contract_test.rs
+++ b/guac_core/tests/contract_test.rs
@@ -452,4 +452,5 @@ fn init_and_query() {
 
     assert_eq!(CRYPTO.get_network_id().wait().unwrap(), *NETWORK_ID);
     assert_eq!(CRYPTO.get_nonce().wait().unwrap(), Uint256::from(0u64));
+    assert_ne!(CRYPTO.get_gas_price().wait().unwrap(), Uint256::from(0u64));
 }

--- a/guac_core/tests/contract_test.rs
+++ b/guac_core/tests/contract_test.rs
@@ -446,6 +446,9 @@ fn init_and_query() {
     let cfg = Config {
         address: "http://127.0.0.1:8545".to_string(),
         contract: CHANNEL_ADDRESS.clone(),
+        secret: "fafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafafa"
+            .parse()
+            .unwrap(),
     };
     CRYPTO.init(&cfg).unwrap();
     assert_ne!(CRYPTO.web3().eth().accounts().wait().unwrap().len(), 0);

--- a/guac_core/tests/contract_test.rs
+++ b/guac_core/tests/contract_test.rs
@@ -445,6 +445,7 @@ fn contract() {
 fn init_and_query() {
     let cfg = Config {
         address: "http://127.0.0.1:8545".to_string(),
+        contract: CHANNEL_ADDRESS.clone(),
     };
     CRYPTO.init(&cfg).unwrap();
     assert_ne!(CRYPTO.web3().eth().accounts().wait().unwrap().len(), 0);

--- a/guac_core/tests/contract_test.rs
+++ b/guac_core/tests/contract_test.rs
@@ -451,4 +451,5 @@ fn init_and_query() {
     assert_ne!(CRYPTO.web3().eth().accounts().wait().unwrap().len(), 0);
 
     assert_eq!(CRYPTO.get_network_id().wait().unwrap(), *NETWORK_ID);
+    assert_eq!(CRYPTO.get_nonce().wait().unwrap(), Uint256::from(0u64));
 }

--- a/guac_core/tests/contract_test.rs
+++ b/guac_core/tests/contract_test.rs
@@ -449,4 +449,6 @@ fn init_and_query() {
     };
     CRYPTO.init(&cfg).unwrap();
     assert_ne!(CRYPTO.web3().eth().accounts().wait().unwrap().len(), 0);
+
+    assert_eq!(CRYPTO.get_network_id().wait().unwrap(), *NETWORK_ID);
 }


### PR DESCRIPTION
Initial effort to integrate web3. `CRYPTO` context is configurable (actually you have to call `init(...)` and later you can rock on with `CRYPTO.web3()` handle directly. Additionally there are (and there will be more) bunch of calls that does the network calls, parses the result, and returns futures directly (i.e. not `web3::Result`) so caller doesn't need to remember chain of `rust-web3` calls. (Side note: Ideally at some point we could just remove `web3()` and only talk through our wrapper calls).

Closes #23 