### PR TITLE
Implement traits

### DIFF
--- a/guac_actix/src/channel_actor.rs
+++ b/guac_actix/src/channel_actor.rs
@@ -4,16 +4,20 @@ use actix::prelude::*;
 use clarity::Address;
 use clarity::Signature;
 use failure::Error;
-use guac_core::eth_client::{
-    close_channel, join_channel, open_channel, start_challenge, update_channel, ChannelId,
-};
+use guac_core::eth_client::EthClient;
+use guac_core::payment_contract::{ChannelId, PaymentContract};
 use num256::Uint256;
 
-pub struct ChannelActorImpl;
+pub struct ChannelActorImpl {
+    contract: Box<PaymentContract>,
+}
 
 impl Default for ChannelActorImpl {
-    fn default() -> Self {
-        Self {}
+    fn default() -> ChannelActorImpl {
+        ChannelActorImpl {
+            /// Creates default implementation with Ethcalate contract
+            contract: Box::new(EthClient::new()),
+        }
     }
 }
 
@@ -47,7 +51,7 @@ impl Handler<OpenChannel> for ChannelActorImpl {
     type Result = ResponseFuture<ChannelId, Error>;
 
     fn handle(&mut self, msg: OpenChannel, _ctx: &mut Context<Self>) -> Self::Result {
-        open_channel(msg.0, msg.1, msg.2)
+        self.contract.open_channel(msg.0, msg.1, msg.2)
     }
 }
 
@@ -62,7 +66,7 @@ impl Handler<JoinChannel> for ChannelActorImpl {
     type Result = ResponseFuture<(), Error>;
 
     fn handle(&mut self, msg: JoinChannel, _ctx: &mut Context<Self>) -> Self::Result {
-        join_channel(msg.0, msg.1)
+        self.contract.join_channel(msg.0, msg.1)
     }
 }
 
@@ -77,7 +81,8 @@ impl Handler<UpdateChannel> for ChannelActorImpl {
     type Result = ResponseFuture<(), Error>;
 
     fn handle(&mut self, msg: UpdateChannel, _ctx: &mut Context<Self>) -> Self::Result {
-        update_channel(msg.0, msg.1, msg.2, msg.3, msg.4, msg.5)
+        self.contract
+            .update_channel(msg.0, msg.1, msg.2, msg.3, msg.4, msg.5)
     }
 }
 
@@ -92,7 +97,7 @@ impl Handler<StartChallenge> for ChannelActorImpl {
     type Result = ResponseFuture<(), Error>;
 
     fn handle(&mut self, msg: StartChallenge, _ctx: &mut Context<Self>) -> Self::Result {
-        start_challenge(msg.0)
+        self.contract.start_challenge(msg.0)
     }
 }
 
@@ -107,7 +112,7 @@ impl Handler<CloseChannel> for ChannelActorImpl {
     type Result = ResponseFuture<(), Error>;
 
     fn handle(&mut self, msg: CloseChannel, _ctx: &mut Context<Self>) -> Self::Result {
-        close_channel(msg.0)
+        self.contract.close_channel(msg.0)
     }
 }
 

--- a/guac_actix/src/lib.rs
+++ b/guac_actix/src/lib.rs
@@ -44,7 +44,6 @@ use channel_actor::{ChannelActor, OpenChannel};
 use clarity::Address;
 use clarity::Signature;
 use futures::future::ok;
-use guac_core::eth_client::ChannelId;
 use network_requests::tick;
 use network_requests::{
     NetworkRequestActor, SendChannelCreatedRequest, SendChannelUpdate, SendProposalRequest,
@@ -248,6 +247,7 @@ impl log::Log for ConsoleLogger {
 
 #[test]
 fn make_payment() {
+    use guac_core::payment_contract::ChannelId;
     *CRYPTO.get_balance_mut() = Uint256::from(100_000_000_000_000u64);
 
     use std::sync::{Arc, Mutex};

--- a/guac_core/src/lib.rs
+++ b/guac_core/src/lib.rs
@@ -24,6 +24,10 @@ extern crate num256;
 extern crate sha3;
 extern crate web3;
 
+// Traits
+pub mod payment_contract;
+
+// Code
 pub mod api;
 pub mod channel_client;
 pub mod counterparty;

--- a/guac_core/src/payment_contract.rs
+++ b/guac_core/src/payment_contract.rs
@@ -1,0 +1,35 @@
+use clarity::Address;
+use clarity::Signature;
+use failure::Error;
+use futures::future::ok;
+use futures::Future;
+use futures::IntoFuture;
+use num256::Uint256;
+
+/// An alias for a channel ID in a raw bytes form
+pub type ChannelId = [u8; 32];
+
+pub trait PaymentContract {
+    fn open_channel(
+        &self,
+        to: Address,
+        challenge: Uint256,
+        value: Uint256,
+    ) -> Box<Future<Item = ChannelId, Error = Error>>;
+    fn join_channel(
+        &self,
+        channel_id: ChannelId,
+        value: Uint256,
+    ) -> Box<Future<Item = (), Error = Error>>;
+    fn update_channel(
+        &self,
+        channel_id: ChannelId,
+        channel_nonce: Uint256,
+        balance_a: Uint256,
+        balance_b: Uint256,
+        sig_a: Signature,
+        sig_b: Signature,
+    ) -> Box<Future<Item = (), Error = Error>>;
+    fn start_challenge(&self, channel_id: ChannelId) -> Box<Future<Item = (), Error = Error>>;
+    fn close_channel(&self, channel_id: ChannelId) -> Box<Future<Item = (), Error = Error>>;
+}


### PR DESCRIPTION
As described in #37 (doc: https://github.com/althea-mesh/guac_rs/blob/master/docs/new-spec.md):

Implements traits and refactors the logic to decouple actual contract logic from actix stuff.

- [x] Implement PaymentContract
- [ ] Implement TransportProtocol trait
  - [ ] Server implementation for HTTP endpoints
  - [ ] Client implementation for HTTP requests
- [ ] Remove ChannelActor from current code and use PaymentContract trait to call the contract functions.
- [ ] Remove NetworkRequestActor from current code and use TransportProtocol trait to do the communication with other nodes

So the end result of that would be clean separation of guac_core from guac_actix.

Also:

- [ ] Figure out a nice way to do the mocking once ChannelActor/NetworkRequestActor is gone (is there anything that is close enough to googletest in rust world?)

Closes #36 