### PR TITLE
Bump web3

### DIFF
--- a/guac_core/Cargo.toml
+++ b/guac_core/Cargo.toml
@@ -17,7 +17,7 @@ serde_derive = "1.0"
 failure = "0.1.1"
 base64 = "0.9.0"
 tiny-keccak = "1.4.1"
-web3 = "0.4"
+web3 = "0.5.0"
 lazy_static = "1.0"
 # XXX: Bumping to 5.1.2 or later brings ethereum-types 0.4 which we don't want to use because other deps use ethereum-types 0.3.
 ethabi = "=5.1.1"


### PR DESCRIPTION
The previous version (0.4.0) depended on openssl which would get upset
on systems with so's for OpenSSL v1.1.1