### PR TITLE
Add web3 request timeout

### DIFF
--- a/guac_core/src/web3/jsonrpc/client.rs
+++ b/guac_core/src/web3/jsonrpc/client.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 use std::cell::RefCell;
 use std::str;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use tokio::net::TcpStream;
 use transport_protocol::TransportProtocol;
 use web3::jsonrpc::request::Request;
@@ -59,6 +60,7 @@ impl Client for HTTPClient {
                 .json(payload)
                 .unwrap()
                 .send()
+                .timeout(Duration::from_millis(1000))
                 .from_err()
                 .and_then(|response| {
                     response


### PR DESCRIPTION
Without a timeout these requests build up in the background and eventually
cause an out of file descriptor error. With this change the number of file
descriptors stops creeping up and becomes stable.